### PR TITLE
Increased unicorn timeout to 120s

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,5 +1,5 @@
 worker_processes Integer(ENV["WEB_CONCURRENCY"] || 3)
-timeout 30
+timeout 120 
 preload_app true
 
 before_fork do |server, worker|


### PR DESCRIPTION
Should enable the CSV to download all records. 